### PR TITLE
autoloading colors by default

### DIFF
--- a/colors.plugin.zsh
+++ b/colors.plugin.zsh
@@ -3,6 +3,6 @@
 # https://wiki.archlinux.org/index.php/Zsh
 #
 # You can also debug this library with `whence -f red`
-
 colors=( black red green yellow blue magenta cyan white )
 autoload -Uz $colors
+autoload -U colors && colors


### PR DESCRIPTION
The plugin would not work without that.

I'm unsure if it is good to do it here, or just add something in the README would be best.