### PR TITLE
Add support for additional zsh plugin managers

### DIFF
--- a/colors.plugin.zsh
+++ b/colors.plugin.zsh
@@ -6,3 +6,4 @@
 colors=( black red green yellow blue magenta cyan white )
 autoload -Uz $colors
 autoload -U colors && colors
+fpath+="`dirname $0`"


### PR DESCRIPTION
Both [zplug](https://github.com/b4b4r07/zplug) and [antibody](https://github.com/getantibody/antibody) do not automatically update the fpath (and antigen doesn't add a path multiple times).

This PR adds the directory containing the plugin to the fpath to allow zsh-colors to work with additional plugin managers.