### PR TITLE
Rename colors.plugin.zsh to zsh-colors.plugin.zsh 

### DIFF
--- a/colors.plugin.zsh
+++ b/colors.plugin.zsh
@@ -1,9 +1,0 @@
-# Content based a bit on this nice documentation:
-#
-# https://wiki.archlinux.org/index.php/Zsh
-#
-# You can also debug this library with `whence -f red`
-colors=( black red green yellow blue magenta cyan white )
-autoload -Uz $colors
-autoload -U colors && colors
-fpath+="`dirname $0`"

--- a/zsh-colors.plugin.zsh
+++ b/zsh-colors.plugin.zsh
@@ -1,1 +1,9 @@
-colors.plugin.zsh
+# Content based a bit on this nice documentation:
+#
+# https://wiki.archlinux.org/index.php/Zsh
+#
+# You can also debug this library with `whence -f red`
+colors=( black red green yellow blue magenta cyan white )
+autoload -Uz $colors
+autoload -U colors && colors
+fpath+="`dirname $0`"

--- a/zsh-colors.plugin.zsh
+++ b/zsh-colors.plugin.zsh
@@ -1,0 +1,1 @@
+colors.plugin.zsh


### PR DESCRIPTION
I made a simple function to load zsh function that assumes the folder name matches the file name, which works for the vast majority of plugins. This change makes it work with this plugin as well, but keeps the original file for compatability.